### PR TITLE
Update berate_ap

### DIFF
--- a/berate_ap
+++ b/berate_ap
@@ -378,7 +378,7 @@ can_transmit_to_channel() {
 
     if [[ $USE_IWCONFIG -eq 0 ]]; then
         if [[ $FREQ_BAND == 2.4 ]]; then
-            CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " 24[0-9][0-9] MHz \[${CHANNEL_NUM}\]")
+            CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " 24[0-9][0-9].0 MHz \[${CHANNEL_NUM}\]")
         else
             CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " \(49[0-9][0-9]\|5[0-9]\{3\}\) MHz \[${CHANNEL_NUM}\]")
         fi


### PR DESCRIPTION
fix for "ERROR: Your adapter can not transmit to channel 1, frequency band 2.4GHz." - see https://github.com/sensepost/berate_ap/issues/12

iw list now seems to add ".0" to the frequency, which causes parsing to fail. may be similar for 5ghz, not tested due to lack of hardware.

```
10:44 root@kali /alex $ iw list | egrep " MHz "                
			* 2412.0 MHz [1] (20.0 dBm)
			* 2417.0 MHz [2] (20.0 dBm)
			* 2422.0 MHz [3] (20.0 dBm)
			* 2427.0 MHz [4] (20.0 dBm)
			* 2432.0 MHz [5] (20.0 dBm)
			* 2437.0 MHz [6] (20.0 dBm)
			* 2442.0 MHz [7] (20.0 dBm)
			* 2447.0 MHz [8] (20.0 dBm)
			* 2452.0 MHz [9] (20.0 dBm)
			* 2457.0 MHz [10] (20.0 dBm)
			* 2462.0 MHz [11] (20.0 dBm)
			* 2467.0 MHz [12] (20.0 dBm)
			* 2472.0 MHz [13] (20.0 dBm)
			* 2484.0 MHz [14] (disabled)
```